### PR TITLE
Modification needed

### DIFF
--- a/model_training/model_training.md
+++ b/model_training/model_training.md
@@ -151,7 +151,7 @@
 ```python
 from sklearn.cross_validation import train_test_split
 
-feature_column_names = ['num_preg', 'glucose_conc', 'diastolic_bp', 'thickness', 'insulin', 'bmi', 'diab_prod', 'age']
+feature_column_names = ['num_preg', 'glucose_conc', 'diastolic_bp', 'thickness', 'insulin', 'bmi', 'diab_pred', 'age']
 
 predicted_class_name = ['diabetes']
 
@@ -161,7 +161,7 @@ X = data_frame[feature_column_names].values
 y = data_frame[predicted_class_name].values
 
 # Saving 30% for testing
-split_test_size = 30
+split_test_size = 0.30
 
 # Splitting using scikit-learn train_test_split function
 


### PR DESCRIPTION
1.  Spelling mistake on `diab_prod`. It should be `diab_pred`.

2. According to `sklearn.model_selection.train_test_split` documentation the `test_size` parameter takes : `float, int, None, optional`. When we use `float` It should be between `0.0` and `1.0`  that represent the proportion of the `dataset`. When we use `int` we need to pass the absolute number of test samples, in this case we need to pass `230` if we want `30%` of test data.